### PR TITLE
Add function to upload submissions

### DIFF
--- a/numerox/api_tournament.py
+++ b/numerox/api_tournament.py
@@ -26,8 +26,6 @@ class ApiTournament:
                 'Token {}${}'.format(public_id, secret_key)
 
         r = requests.post(API_TOURNAMENT_URL, json=body, headers=headers)
-        print(r)
-        print(r.text)
         return r.json()
 
     def upload_submission(self, full_filename):
@@ -57,4 +55,4 @@ class ApiTournament:
             '''
         create = self.call(create_query,
                            {'filename': submission_auth['filename']})
-        print(create)
+        return create['data']['create_submission']['id']

--- a/numerox/api_tournament.py
+++ b/numerox/api_tournament.py
@@ -1,0 +1,60 @@
+import requests
+import os
+
+API_TOURNAMENT_URL = 'https://api-tournament.numer.ai'
+
+
+class ApiTournament:
+
+    def __init__(self, public_id=None, secret_key=None):
+        if public_id and secret_key:
+            self.token = (public_id, secret_key)
+        elif not public_id and not secret_key:
+            self.token = None
+        else:
+            print("You supply both a public id and a secret key.")
+            self.token = None
+
+    def call(self, query, variables=None):
+        body = {'query': query,
+                'variables': variables}
+        headers = {'Content-type': 'application/json',
+                   'Accept': 'application/json'}
+        if self.token:
+            public_id, secret_key = self.token
+            headers['Authorization'] = \
+                'Token {}${}'.format(public_id, secret_key)
+
+        r = requests.post(API_TOURNAMENT_URL, json=body, headers=headers)
+        print(r)
+        print(r.text)
+        return r.json()
+
+    def upload_submission(self, full_filename):
+        filename = os.path.basename(full_filename)
+        if not self.token:
+            print("You supply an API token to upload.")
+        auth_query = \
+            '''
+            query($filename: String!) {
+                submission_upload_auth(filename: $filename) {
+                    filename
+                    url
+                }
+            }
+            '''
+        submission_resp = self.call(auth_query, {'filename': filename})
+        submission_auth = submission_resp['data']['submission_upload_auth']
+        file_object = open(full_filename, 'rb').read()
+        requests.put(submission_auth['url'], data=file_object)
+        create_query = \
+            '''
+            mutation($filename: String!) {
+                create_submission(filename: $filename) {
+                    id
+                }
+            }
+            '''
+        create = self.call(create_query,
+                           {'filename': submission_auth['filename']})
+        print(create)


### PR DESCRIPTION
Here's some boilerplate to upload a submission.  Please feel free to take this and restructure it any way you want.  For example, perhaps `upload_submission()` shouldn't be in the same class as `call()`

To use this, you'll need an API token.  Jonathan is working on a front end for them, but in the meantime, if you're logged in to the website, you can generate a token for yourself at the dev console with: 

```
MyApp.fetchApiTournament('mutation($password: String!, $code: String, $name: String!) {createApiToken(password: $password, code: $code, name: $name, scopes: ["upload_submission"]) {scopes secretKey publicId name}}', {password: "mypassword", code: "123456", name: "my first API token"}).then(console.log)
```

Obviously, replace your own password and optional 2FA token (if you don't have 2FA enabled, just omit those fields).

You'll get back an object that has a public id and a secret key.  You can use those to upload a submission:

```
>>> from api_tournament import ApiTournament
>>> a = ApiTournament("<PUBLIC-ID>", "<SECRET-KEY>")
>>> a.upload_submission("<FILE-PATH>")
```