### PR TITLE
fixes #11 Add support for sklearn.pipeline.Pipeline

### DIFF
--- a/numerox/__init__.py
+++ b/numerox/__init__.py
@@ -11,6 +11,7 @@ from numerox.model import logistic
 from numerox.model import extratrees
 from numerox.model import randomforest
 from numerox.model import xgboost
+from numerox.model import pipeline
 
 # load
 from numerox.data import load_data, load_zip

--- a/numerox/model.py
+++ b/numerox/model.py
@@ -1,9 +1,10 @@
 import json
+from typing import List
 
 import numpy as np
-from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import ExtraTreesClassifier as ETC
 from sklearn.ensemble import RandomForestClassifier as RFC
+from sklearn.linear_model import LogisticRegression
 
 try:
     from xgboost.sklearn import XGBClassifier
@@ -70,12 +71,42 @@ class Model(object):
 
 
 class logistic(Model):
-
     def __init__(self, inverse_l2=0.0001):
         self.p = {'inverse_l2': inverse_l2}
+        self.clf = None
 
     def fit_predict(self, data_fit, data_predict):
-        model = LogisticRegression(C=self.p['inverse_l2'])
+        self.fit(data_fit.x, data_fit.y)
+        yhat = self.predict_proba(data_predict.x)[:, 1]
+        return data_predict.ids, yhat
+
+    def get_model(self):
+        return LogisticRegression(C=self.p['inverse_l2'])
+
+    def fit(self, x, y):
+        if self.clf is None:
+            self.clf = self.get_model()
+        self.clf.fit(x, y)
+
+    def predict_proba(self, x):
+        return self.clf.predict_proba(x)
+
+
+class pipeline(Model):
+    def __init__(self, models: List[Model]):
+        self._models = [(model.__class__.__name__, model) for model in models]
+
+    @property
+    def models(self) -> list:
+        return list(self._models)
+
+    @models.setter
+    def models(self, models):
+        self._models = models
+
+    def fit_predict(self, data_fit, data_predict):
+        from sklearn.pipeline import Pipeline
+        model = Pipeline(steps=self.models)
         model.fit(data_fit.x, data_fit.y)
         yhat = model.predict_proba(data_predict.x)[:, 1]
         return data_predict.ids, yhat

--- a/numerox/model.py
+++ b/numerox/model.py
@@ -93,16 +93,8 @@ class logistic(Model):
 
 
 class pipeline(Model):
-    def __init__(self, models: List[Model]):
-        self._models = [(model.__class__.__name__, model) for model in models]
-
-    @property
-    def models(self) -> list:
-        return list(self._models)
-
-    @models.setter
-    def models(self, models):
-        self._models = models
+    def __init__(self, models):
+        self.models = [(model.__class__.__name__, model) for model in models]
 
     def fit_predict(self, data_fit, data_predict):
         from sklearn.pipeline import Pipeline

--- a/numerox/model.py
+++ b/numerox/model.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 
 import numpy as np
 from sklearn.ensemble import ExtraTreesClassifier as ETC

--- a/numerox/tests/test_model.py
+++ b/numerox/tests/test_model.py
@@ -31,3 +31,13 @@ def test_model_run():
     d_predict = d['tournament']
     for model in get_models():
         model.fit_predict(d_fit, d_predict)
+
+
+def test_pipeline():
+    d = nx.play_data()
+    d_fit = d['train']
+    d_predict = d['tournament']
+    model = nx.pipeline([
+        nx.logistic()
+    ])
+    model.fit_predict(d_fit, d_predict)


### PR DESCRIPTION
The models needs to be updated to defer fit() and predict_proba() for them to be usable in a pipeline. I refactored logistic() as an example:

```
class logistic(Model):
    def __init__(self, inverse_l2=0.0001):
        self.p = {'inverse_l2': inverse_l2}
        self.clf = None

    def fit_predict(self, data_fit, data_predict):
        self.fit(data_fit.x, data_fit.y)
        yhat = self.predict_proba(data_predict.x)[:, 1]
        return data_predict.ids, yhat

    def get_model(self):
        return LogisticRegression(C=self.p['inverse_l2'])

    def fit(self, x, y):
        if self.clf is None:
            self.clf = self.get_model()
        self.clf.fit(x, y)

    def predict_proba(self, x):
        return self.clf.predict_proba(x)
```