### PR TITLE
Compatible zip format for tournament #132

### DIFF
--- a/numerox/data.py
+++ b/numerox/data.py
@@ -7,8 +7,8 @@ from sklearn.neighbors import NearestNeighbors
 
 import numerox as nx
 
-TRAIN_FILE = 'numerai_training_data.csv'
-TOURNAMENT_FILE = 'numerai_tournament_data.csv'
+TRAIN_FILE = 'numerai_datasets/numerai_training_data.csv'
+TOURNAMENT_FILE = 'numerai_datasets/numerai_tournament_data.csv'
 HDF_DATA_KEY = 'numerox_data'
 
 ERA_INT_TO_STR = {}


### PR DESCRIPTION
The #132 contains a folder in the zip: numerai_datasets. To make it compatible we need the folder to be on the path. Or... maybe that is one time deal while in transition